### PR TITLE
Fixes the GraphQL error when creating User-Agent match & replace rule

### DIFF
--- a/packages/frontend/src/composables/useCaidoConfig.ts
+++ b/packages/frontend/src/composables/useCaidoConfig.ts
@@ -38,7 +38,7 @@ export function useCaidoConfig() {
         name: programName,
         collectionId: collection?.id,
         isEnabled: true,
-        sources: ["INTERCEPT" as const, "AUTOMATE" as const],
+        sources: [],
         
         section: {
          kind: "SectionRequestHeader",

--- a/packages/frontend/src/composables/useCaidoConfig.ts
+++ b/packages/frontend/src/composables/useCaidoConfig.ts
@@ -36,8 +36,9 @@ export function useCaidoConfig() {
     try {
       await sdk.matchReplace.createRule({
         name: programName,
-        collectionId: collection?.id, // 3
+        collectionId: collection?.id,
         isEnabled: true,
+        sources: ["INTERCEPT" as const, "AUTOMATE" as const],
         
         section: {
          kind: "SectionRequestHeader",


### PR DESCRIPTION
Fixes the GraphQL error when creating User-Agent match & replace rules via the YesWeCaido plugin.

When clicking "Add user-agent" in the plugin, users received this error:

[GraphQL] Invalid value for argument "input", field "sources" of type "[Source!]!" is required but not provided

Added the missing sources field to the createRule call with values ["INTERCEPT", "AUTOMATE"].

The Caido GraphQL API requires this field, but the SDK TypeScript definitions don't yet reflect this requirement, so the field was overlooked in the original implementation.